### PR TITLE
Capture team name install notification

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,5 +27,5 @@ slack.on('interactive_message', async (msg, bot) => {
 });
 
 slack.on('install_success', (payload) => {
-  notificationService.newCustomer();
+  notificationService.newCustomer(payload);
 });

--- a/lib/NotificationService.ts
+++ b/lib/NotificationService.ts
@@ -10,8 +10,8 @@ export class NotificationService {
 
   newCustomer(payload) {
     const customer = JSON.parse(payload);
-    const install_team = customer.team.name 
-    this.send(`New customer ${install_team} has installed Since!`);
+    const installTeam = customer.team.name 
+    this.send(`New customer ${installTeam} has installed Since!`);
   }
 
   private send(text: string) {

--- a/lib/NotificationService.ts
+++ b/lib/NotificationService.ts
@@ -8,8 +8,10 @@ export class NotificationService {
     this.webhook = process.env.WEBHOOK;
   }
 
-  newCustomer() {
-    this.send('New customer has installed Since!');
+  newCustomer(payload) {
+    const customer = JSON.parse(payload);
+    const install_team = customer.team.name 
+    this.send(`New customer ${install_team} has installed Since!`);
   }
 
   private send(text: string) {


### PR DESCRIPTION
Passes the install payload to the notification service to then include the installing team name in the install notification.