### PR TITLE
Adjusts install team name for legacy Oauth2 payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ jspm_packages
 
 # Webpack directories
 .webpack
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/lib/NotificationService.ts
+++ b/lib/NotificationService.ts
@@ -10,7 +10,7 @@ export class NotificationService {
 
   newCustomer(payload) {
     const customer = JSON.parse(payload);
-    const installTeam = customer.team.name;
+    const installTeam = customer.team_name;
     this.send(`New customer ${installTeam} has installed Since!`);
   }
 

--- a/lib/NotificationService.ts
+++ b/lib/NotificationService.ts
@@ -10,7 +10,15 @@ export class NotificationService {
 
   newCustomer(payload) {
     const customer = JSON.parse(payload);
-    const installTeam = customer.team_name;
+    var installTeam = "Unknown";
+    if (customer.hasOwnProperty("team_name")) {
+      installTeam = customer.team_name;
+    }
+    else if (customer.hasOwnProperty("team")) {
+      installTeam = customer.team.name;
+    }
+
+    
     this.send(`New customer ${installTeam} has installed Since!`);
   }
 


### PR DESCRIPTION
Still on oauth legacy where the team name param is different.

See this example https://api.slack.com/legacy/oauth#bots